### PR TITLE
Flush stdout to ensure image is fully sent

### DIFF
--- a/host_applications/linux/apps/raspicam/RaspiStillYUV.c
+++ b/host_applications/linux/apps/raspicam/RaspiStillYUV.c
@@ -1376,6 +1376,10 @@ int main(int argc, const char **argv)
                {
                   rename_file(&state, output_file, final_filename, use_filename, frame);
                }
+               else
+               {
+                  fflush(output_file);
+               }
             }
 
             if (use_filename)


### PR DESCRIPTION
Flush stdout when dumping image data over stdout. Without the flush, using signals to stream image data over stdout would result in the missing data, if the buffer didn't fill the 65536 chunk.
